### PR TITLE
Add close method to AsynchronousBytesToBits

### DIFF
--- a/b2bapi/wrapper.py
+++ b/b2bapi/wrapper.py
@@ -1,4 +1,5 @@
 import requests, aiohttp, asyncio
+from typing import Optional
 from time import sleep
 from .meme import Meme
 from .madlib import Madlib
@@ -39,36 +40,39 @@ class BytesToBits:
         return Madlib(ret['title'], ret['text'], ret['questions'], ret['variables'])
 
 class AsynchronousBytesToBits:
-
-    def __init__(self, token: str) -> None:
+    def __init__(self, token: str, session: Optional[aiohttp.ClientSession] = None) -> None:
         self.auth_header = {
             'Authorization': token
         }
         self.BASE_URL = 'https://api.bytestobits.dev'
+        if not session:
+            self.session = aiohttp.ClientSession()
+        else:
+            self.session = session
         return
 
     async def get_word(self) -> Word:
         "Returns a random word from the API in an asynchronous context"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f'{self.BASE_URL}/word/', headers=self.auth_header) as request:
-                return Word(await request.json())
+        async with self.session.get(f'{self.BASE_URL}/word/', headers=self.auth_header) as request:
+            return Word(await request.json())
     
     async def get_text(self) -> Text:
         "Returns a random paragraph from the API in an asynchronous context"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f'{self.BASE_URL}/text/', headers=self.auth_header) as request:
-                return Text(await request.json())
+        async with self.session.get(f'{self.BASE_URL}/text/', headers=self.auth_header) as request:
+            return Text(await request.json())
 
     async def get_meme(self) -> Meme:
         "Returns a random meme from a random subreddit through the API in an asynchronous context"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f'{self.BASE_URL}/meme/', headers=self.auth_header) as request:
-                ret = await request.json()
-                return Meme(ret['title'], ret['url'], ret['link'], ret['subreddit'])
+        async with self.session.get(f'{self.BASE_URL}/meme/', headers=self.auth_header) as request:
+            ret = await request.json()
+            return Meme(ret['title'], ret['url'], ret['link'], ret['subreddit'])
 
     async def get_madlib(self) -> Madlib:
         "Returns a random madlib from the API in an asynchronous context"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f'{self.BASE_URL}/madlibs/', headers=self.auth_header) as request:
-                ret = await request.json()
-                return Madlib(ret['title'], ret['text'], ret['questions'], ret['variables'])
+        async with self.session.get(f'{self.BASE_URL}/madlibs/', headers=self.auth_header) as request:
+            ret = await request.json()
+            return Madlib(ret['title'], ret['text'], ret['questions'], ret['variables'])
+
+    async def close(self) -> None:
+        "Close the client"
+        self.session.close()


### PR DESCRIPTION
This PR introduces reduces the creation of ClientSession for each request and introduces an `async close()` method which shall be used to free the resources acquired by the underlying ClientSession instance. 

The client is expected to be closed by the user. However, a hacky method such as `add_exit_handler` could be added to close the client by itself at the exit.

The usage is similar to
```py
import asyncio
from b2bapi import AsynchronousBytesToBits as Client

client = Client("<token>")

async def main(): # Some requests in an app
    print(await client.get_word())

if __name__ == "__main__":
    loop = asyncio.get_event_loop()
    try:
        loop.run_until_complete(main())
    except KeyboardInterrupt:
        pass
    finally:
        loop.run_until_complete(client.close()) # close the client
        loop.close()
```